### PR TITLE
Make sameTypeAs return false if no tile was passed in, remove tileBel…

### DIFF
--- a/lib/tile.js
+++ b/lib/tile.js
@@ -67,9 +67,9 @@ Tile.prototype.drop = function() {
 }
 
 Tile.prototype.horizontalLineLength = function() {
-	if(this.tileToTheRight()){
-		if(this.tileToTheRight().type == this.type) {
-			return this.tileToTheRight().horizontalLineLength() + 1;
+	if(this.relativeTile(0, -1)){
+		if(this.relativeTile(0, -1).type == this.type) {
+			return this.relativeTile(0, -1).horizontalLineLength() + 1;
 		} else {
 			return 1;
 		}
@@ -79,9 +79,9 @@ Tile.prototype.horizontalLineLength = function() {
 }
 
 Tile.prototype.verticalLineLength = function() {
-	if(this.tileBelow()){
-		if(this.tileBelow().type == this.type) {
-			return this.tileBelow().verticalLineLength() + 1;
+	if(this.relativeTile(-1, 0)){
+		if(this.relativeTile(-1, 0).type == this.type) {
+			return this.relativeTile(-1, 0).verticalLineLength() + 1;
 		} else {
 			return 1;
 		}
@@ -91,9 +91,9 @@ Tile.prototype.verticalLineLength = function() {
 }
 
 Tile.prototype.topmostTileInLine = function() {
-	if(this.tileAbove()){
-		if(this.tileAbove().type == this.type) {
-			return this.tileAbove().topmostTileInLine();
+	if(this.relativeTile(1, 0)){
+		if(this.relativeTile(1, 0).type == this.type) {
+			return this.relativeTile(1, 0).topmostTileInLine();
 		} else {
 			return this;
 		}
@@ -103,9 +103,9 @@ Tile.prototype.topmostTileInLine = function() {
 };
 
 Tile.prototype.leftmostTileInLine = function() {
-	if(this.tileToTheLeft()){
-		if(this.tileToTheLeft().type == this.type) {
-			return this.tileToTheLeft().leftmostTileInLine();
+	if(this.relativeTile(0, 1)){
+		if(this.relativeTile(0, 1).type == this.type) {
+			return this.relativeTile(0, 1).leftmostTileInLine();
 		} else {
 			return this;
 		}
@@ -128,22 +128,6 @@ Tile.prototype.relativeTile =  function (rowOffset, columnOffset) {
 	return this.board.findTileAtRowAndColumn(this.row + rowOffset, this.column + columnOffset);
 }
 
-Tile.prototype.tileToTheLeft = function() {
-	return this.relativeTile(0, -1);
-}
-
-Tile.prototype.tileToTheRight = function() {
-	return this.relativeTile(0, 1);
-}
-
-Tile.prototype.tileBelow = function() {
-	return this.relativeTile(1, 0);
-}
-
-Tile.prototype.tileAbove = function() {
-	return this.relativeTile(-1, 0);
-}
-
 Tile.prototype.setClear = function() {
 	this.toClear = true;
 	return this;
@@ -158,29 +142,33 @@ Tile.prototype.containsPoint = function(x,y) {
 }
 
 Tile.prototype.sameTypeAs = function(tile) {
-	return this.type == tile.type;
+	if(tile) { 
+		return this.type == tile.type;
+	} else {
+		return false;
+	}
 }
 
 Tile.prototype.possibleMatch = function() {
-	if(this.tileBelow() && this.tileBelow().sameTypeAs(this)) {
-		if(this.relativeTile(-2, 0) && this.relativeTile(-2, 0).sameTypeAs(this)){return true;}
-		if(this.relativeTile(-1, 1) && this.relativeTile(-1, 1).sameTypeAs(this)){return true;}
-		if(this.relativeTile(1, 1) && this.relativeTile(1, 1).sameTypeAs(this)){return true;}
+	if(this.relativeTile(-1, 0).sameTypeAs(this)) {
+		if(this.relativeTile(-2, 0).sameTypeAs(this)){return true;}
+		if(this.relativeTile(-1, 1).sameTypeAs(this)){return true;}
+		if(this.relativeTile(1, 1).sameTypeAs(this)){return true;}
 	}
-	if(this.tileAbove() && this.tileAbove().sameTypeAs(this)) {
-		if(this.relativeTile(2, 0) && this.relativeTile(2, 0).sameTypeAs(this)){return true;}
-		if(this.relativeTile(1, -1) && this.relativeTile(1, -1).sameTypeAs(this)){return true;}
-		if(this.relativeTile(1, 1) && this.relativeTile(1, 1).sameTypeAs(this)){return true;}
+	if(this.relativeTile(1, 0).sameTypeAs(this)) {
+		if(this.relativeTile(2, 0).sameTypeAs(this)){return true;}
+		if(this.relativeTile(1, -1).sameTypeAs(this)){return true;}
+		if(this.relativeTile(1, 1).sameTypeAs(this)){return true;}
 	}
-	if(this.tileToTheLeft() && this.tileToTheLeft().sameTypeAs(this)) {
-		if(this.relativeTile(0, 2) && this.relativeTile(0, 2).sameTypeAs(this)){return true;}
-		if(this.relativeTile(1, 1) && this.relativeTile(1, 1).sameTypeAs(this)){return true;}
-		if(this.relativeTile(1, -1) && this.relativeTile(1, -1).sameTypeAs(this)){return true;}
+	if(this.relativeTile(0, 1).sameTypeAs(this)) {
+		if(this.relativeTile(0, 2).sameTypeAs(this)){return true;}
+		if(this.relativeTile(1, 1).sameTypeAs(this)){return true;}
+		if(this.relativeTile(1, -1).sameTypeAs(this)){return true;}
 	}
-	if(this.tileToTheRight() && this.tileToTheRight().sameTypeAs(this)) {
-		if(this.relativeTile(0, -2) && this.relativeTile(0, -2).sameTypeAs(this)){return true;}
-		if(this.relativeTile(-1, -1) && this.relativeTile(-1, -1).sameTypeAs(this)){return true;}
-		if(this.relativeTile(-1, 1) && this.relativeTile(-1, 1).sameTypeAs(this)){return true;}
+	if(this.relativeTile(0, -1).sameTypeAs(this)) {
+		if(this.relativeTile(0, -2).sameTypeAs(this)){return true;}
+		if(this.relativeTile(-1, -1).sameTypeAs(this)){return true;}
+		if(this.relativeTile(-1, 1).sameTypeAs(this)){return true;}
 	}
 	return false;
 }


### PR DESCRIPTION
…ow etc.

@rrgayhart, @bad6e
#### What's this PR do?

Previously, the Tile class was full of unnecessary checks for tile existence and methods for getting specific tiles relative to a particular one. This pull request removes the methods tileToTheLeft, tileToTheRight, tileAbove, and tileBelow, and reworks the sameTypeAs method to return false if no tile was passed in instead of causing an error.
#### Where should the reviewer start?

lib/tile.js has all the changes.
#### How should this be manually tested?

Feel free to clone and run the package on the tile-scrubbing branch.
#### Any background context you want to provide?

Not really.
#### Screenshots (if appropriate)

they're not, there shouldn't be a behavior change
#### What gif best describes this PR or how it makes you feel?

http://45.media.tumblr.com/b87de6969b2d1b05ee0b5f08ce46a752/tumblr_nx992ymIei1uiwpaqo1_500.gif
